### PR TITLE
Fix Student CV view when portfolioUrls is null.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,8 @@ import React, {useContext, useEffect} from 'react';
 import './App.css';
 import {Routing} from "./components/Routing/Routing";
 import {Context} from "./provider/Provider";
-
-import {Menu} from "./components/Menu/Menu";
 import {CheckLogin} from "./utils/dictionaries";
 import {Header} from "./components/Header/Header";
-
-
 
 function App() {
 
@@ -25,7 +21,7 @@ function App() {
                     if (data.logedIn) {
                         setLogin(true)
                         setName(data.message.firstName)
-                        setLastName(data.message.lasyName)
+                        setLastName(data.message.lastName)
                         setRole(data.message.role)
                     }
                 })
@@ -35,14 +31,10 @@ function App() {
 
     return (
         <div className="App">
-
             {login ? <Header/> : null}
-         
 
             <Routing login={login}/>
         </div>
-
-
     );
 }
 

--- a/src/components/CvLabelWithLinks/CvLabelWithLinks.tsx
+++ b/src/components/CvLabelWithLinks/CvLabelWithLinks.tsx
@@ -3,7 +3,7 @@ import './CvLabelWithLinks.css';
 import {ProjectOneLink} from "../ProjectOneLink/ProjectOneLink";
 
 interface Props {
-    urlList: string[];
+    urlList: string[] | null;
     title: string;
 }
 
@@ -13,7 +13,7 @@ export const CvLabelWithLinks = (props: Props) => {
         <div className="CvLabelWithLinks">
 
             {
-                props.urlList.length === 0 ?
+                ((props.urlList === null) || (props.urlList.length === 0)) ?
                     <p>Osoba nie posiada strony www z portfolio.</p> : props.urlList.map((element, index) => {
                         return <ProjectOneLink link={element} key={index}/>
                     })

--- a/src/utils/get-one-student-data.ts
+++ b/src/utils/get-one-student-data.ts
@@ -32,7 +32,7 @@ export interface StudentCVResponse {
     id: string;
     lastName: string;
     monthsOfCommercialExp: number;
-    portfolioUrls: string[];
+    portfolioUrls: string[] | null;
     projectDegree: number;
     projectUrls: string[];
     targetWorkCity: string;


### PR DESCRIPTION
Fixed student's CV view (empty page) when he didn't have a portfolio urls.